### PR TITLE
Correct types in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
         "stringify"
     ],
     "main": "dist/index.js",
-    "types": "dist/index.d.js",
-    "typings": "dist/index.d.js",
+    "types": "dist/index.d.ts",
+    "typings": "dist/index.d.ts",
     "license": "MIT",
     "repository": "https://github.com/haoadoresorange/when-json-met-bigint",
     "author": "haoadoresorange",


### PR DESCRIPTION
`types` and `typings` fields in `package.json` are pointing to a missing file. It may break imports (from `Deno` in my case).

https://publint.dev/when-json-met-bigint@0.27.0